### PR TITLE
Removed command updating the vendored sources (of libbuildpack).

### DIFF
--- a/tasks/update-libbuildpack/run.sh
+++ b/tasks/update-libbuildpack/run.sh
@@ -19,13 +19,11 @@ fi
 
 pushd buildpack
 	pushd "$update_dir"
-		go get github.com/FiloSottile/gvt
 		go get github.com/golang/mock/gomock
 		go get github.com/golang/mock/mockgen
 		go get github.com/onsi/ginkgo/ginkgo
 		go get github.com/onsi/gomega
 
-		gvt update github.com/cloudfoundry/libbuildpack
 		go generate
 		ginkgo -r
 	popd


### PR DESCRIPTION
Fixes https://trello.com/c/6yxithdJ/125-staticfile-buildpack-update-libbuildpack-job-fails
Fixes https://trello.com/c/dDkEWu1x/124-go-buildpack-update-libbuildpack-job-fails
(The two pipelines in question share the task and its code, with a single conditional to handle the very small differences in the sources between the two buildpacks)

Doing the update breaks the build, introducing a revision of
libbuildpack which does not match code using it. It is suspected that
the vendoring manifest refers to a different version than we have
actually vendored in the repo.

Generally speaking it should never be necessary to update vendored
code in a CI. Having the proper required revisions of dependencies in
the repository itself is what vendoring is for.