### PR TITLE
Fix SUSE bot email address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ RUN cd /usr/local && bundle install
 
 #install fly-cli
 RUN curl "https://buildpacks.ci.cf-app.com/api/v1/cli?arch=amd64&platform=linux" -sfL -o /usr/local/bin/fly \
-  && [ a61457b5fe15091f8df8013c307875831cf020163c915fb4f6408d2f8647c0aa = $(shasum -a 256 /usr/local/bin/fly | cut -d' ' -f1) ] \
+  && [ fa7e9603b6e1b358dbd657f9c110eea4257e95c19162507850d2ae1fa53f144f = $(shasum -a 256 /usr/local/bin/fly | cut -d' ' -f1) ] \
   && chmod +x /usr/local/bin/fly
 
 # git-hooks and git-secrets

--- a/public-config.yml
+++ b/public-config.yml
@@ -21,7 +21,7 @@ buildpacks-ci-git-uri: git@github.com:SUSE/cf-buildpacks-ci.git
 buildpacks-ci-git-uri-public-develop-branch: develop
 buildpacks-ci-git-uri-public-branch: master
 
-buildpacks-docker-ci-repo: cfbuildpacks/ci
+buildpacks-docker-ci-repo: splatform/ci
 buildpacks-docker-user-email: cf-ci-bot@suse.de
 buildpacks-concourse2tracker-docker-repo: cfbuildpacks/concourse2tracker
 

--- a/public-config.yml
+++ b/public-config.yml
@@ -21,7 +21,7 @@ buildpacks-ci-git-uri: git@github.com:SUSE/cf-buildpacks-ci.git
 buildpacks-ci-git-uri-public-develop-branch: develop
 buildpacks-ci-git-uri-public-branch: master
 
-buildpacks-docker-ci-repo: splatform/ci
+buildpacks-docker-ci-repo: splatform/cf-ci-buildpacks
 buildpacks-docker-user-email: cf-ci-bot@suse.de
 buildpacks-concourse2tracker-docker-repo: cfbuildpacks/concourse2tracker
 

--- a/secrets-map.yaml
+++ b/secrets-map.yaml
@@ -8,6 +8,11 @@
 buildpacks-binaries-s3-endpoint: s3.amazonaws.com
 buildpacks-docker-password: *docker-password
 buildpacks-docker-username: *docker-username
+
+# See pipelines/dockerfile.yml
+buildpacks-docker-user-username: *docker-username
+buildpacks-docker-user-password: *docker-password
+
 cf-buildpacks-public-tracker-id:
 cf-buildpacks-requester-id:
 concourse-job-failure-notifications-slack-channel:

--- a/tasks/add-flake-attempts-to-cats/task.yml
+++ b/tasks/add-flake-attempts-to-cats/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 
 inputs:
 - name: buildpacks-ci

--- a/tasks/build-buildpack-checksums-site/task.yml
+++ b/tasks/build-buildpack-checksums-site/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpack-checksums
 outputs:

--- a/tasks/bump-gem-version/task.yml
+++ b/tasks/bump-gem-version/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: gem

--- a/tasks/check-can-i-bump/task.yml
+++ b/tasks/check-can-i-bump/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
 run:

--- a/tasks/check-for-binary-builder-integration-spec-presence/task.yml
+++ b/tasks/check-for-binary-builder-integration-spec-presence/task.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: binary-builder
   - name: buildpacks-ci

--- a/tasks/check-for-latest-php-module-versions/task.yml
+++ b/tasks/check-for-latest-php-module-versions/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: cassandra-cpp-driver
   - name: librdkafka

--- a/tasks/check-for-new-buildpack-cves/task.yml
+++ b/tasks/check-for-new-buildpack-cves/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: new-buildpack-cves
   - name: buildpacks-ci

--- a/tasks/check-for-new-buildpack-dependency-releases/task.yml
+++ b/tasks/check-for-new-buildpack-dependency-releases/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: new-releases
   - name: buildpacks-ci

--- a/tasks/check-for-new-rootfs-cves/task.yml
+++ b/tasks/check-for-new-rootfs-cves/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: new-cves
   - name: buildpacks-ci

--- a/tasks/check-if-bosh-lite-resource-exists/task.yml
+++ b/tasks/check-if-bosh-lite-resource-exists/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: resource-pools

--- a/tasks/check-tag-not-already-added/task.yml
+++ b/tasks/check-tag-not-already-added/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/checkout-cf-release/task.yml
+++ b/tasks/checkout-cf-release/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: cf-bosh-release
 outputs:

--- a/tasks/checkout-diego-release/task.yml
+++ b/tasks/checkout-diego-release/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: diego-bosh-release
 outputs:

--- a/tasks/collect-cflinuxfs2-nc-files/task.yml
+++ b/tasks/collect-cflinuxfs2-nc-files/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: bosh-release-s3

--- a/tasks/comment-cve-story/task.yml
+++ b/tasks/comment-cve-story/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: version

--- a/tasks/convert-release-to-version/task.yml
+++ b/tasks/convert-release-to-version/task.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: blob
 outputs:

--- a/tasks/copy-cf-acceptance-tests/task.yml
+++ b/tasks/copy-cf-acceptance-tests/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: cf-release

--- a/tasks/create-bosh-release/task.yml
+++ b/tasks/create-bosh-release/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: blob

--- a/tasks/create-buildpack-bosh-release/task.yml
+++ b/tasks/create-buildpack-bosh-release/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: blob

--- a/tasks/create-buildpack-release-tracker-story/task.yml
+++ b/tasks/create-buildpack-release-tracker-story/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 
 inputs:
   - name: buildpacks-ci

--- a/tasks/create-cf-bosh-release-to-deploy/task.yml
+++ b/tasks/create-cf-bosh-release-to-deploy/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: cf-release

--- a/tasks/create-cf-release-without-modifying-cflinuxfs2/task.yml
+++ b/tasks/create-cf-release-without-modifying-cflinuxfs2/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: cf-release
   - name: buildpacks-ci

--- a/tasks/create-cflinuxfs2-release/task.yml
+++ b/tasks/create-cflinuxfs2-release/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: blob

--- a/tasks/create-gem-release/task.yml
+++ b/tasks/create-gem-release/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: gem

--- a/tasks/create-latest-upstream-changes-story/task.yml
+++ b/tasks/create-latest-upstream-changes-story/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
 run:

--- a/tasks/create-new-bosh-deployment-components-story/task.yml
+++ b/tasks/create-new-bosh-deployment-components-story/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: public-buildpacks-ci-robots

--- a/tasks/create-new-cflinuxfs2-release-story/task.yml
+++ b/tasks/create-new-cflinuxfs2-release-story/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
 run:

--- a/tasks/create-rootfs-bosh-release-commit/task.yml
+++ b/tasks/create-rootfs-bosh-release-commit/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: release-artifacts
 outputs:

--- a/tasks/create-rootfs-bosh-release-github-release-notes/task.yml
+++ b/tasks/create-rootfs-bosh-release-github-release-notes/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: version

--- a/tasks/delete-cf-space/task-bp.yml
+++ b/tasks/delete-cf-space/task-bp.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
 run:

--- a/tasks/delete-cf-space/task-brat.yml
+++ b/tasks/delete-cf-space/task-brat.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
 run:

--- a/tasks/delete-cf-space/task-cf.yml
+++ b/tasks/delete-cf-space/task-cf.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: cf-space

--- a/tasks/delete-unaffected-stories/task.yml
+++ b/tasks/delete-unaffected-stories/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: tracker-filter-resource

--- a/tasks/destroy-bosh-lite/task.yml
+++ b/tasks/destroy-bosh-lite/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: deployments-buildpacks

--- a/tasks/detect-and-upload/task.yml
+++ b/tasks/detect-and-upload/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: pivotal-buildpack
   - name: pivotal-buildpack-cached

--- a/tasks/finalize-buildpack/task.yml
+++ b/tasks/finalize-buildpack/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/generate-cf-and-diego-manifests/task.yml
+++ b/tasks/generate-cf-and-diego-manifests/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: bosh-lite
   - name: buildpacks-ci

--- a/tasks/generate-cflinuxfs2-receipt-diff/task.yml
+++ b/tasks/generate-cflinuxfs2-receipt-diff/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: previous-cflinuxfs2-release

--- a/tasks/generate-cflinuxfs2-release-notes/task.yml
+++ b/tasks/generate-cflinuxfs2-release-notes/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: previous-cflinuxfs2-release

--- a/tasks/get-commit-shasums/task.yml
+++ b/tasks/get-commit-shasums/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: buildpack-checksums

--- a/tasks/machete-configure-deployment/task.yml
+++ b/tasks/machete-configure-deployment/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: machete

--- a/tasks/make-rootfs-smoke-test-manifest/task.yml
+++ b/tasks/make-rootfs-smoke-test-manifest/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: cflinuxfs2-release

--- a/tasks/make-rootfs/task.yml
+++ b/tasks/make-rootfs/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: cflinuxfs2

--- a/tasks/overwrite-cflinuxfs2-release/task.yml
+++ b/tasks/overwrite-cflinuxfs2-release/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: stack-s3

--- a/tasks/package-cached-buildpack/task.yml
+++ b/tasks/package-cached-buildpack/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 
 inputs:
   - name: buildpack-master

--- a/tasks/populate-php-modules-in-manifest/task.yml
+++ b/tasks/populate-php-modules-in-manifest/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/push-binary/task.yml
+++ b/tasks/push-binary/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: binary-builder-artifacts
   - name: buildpacks-ci

--- a/tasks/queue-dependency-build/task.yml
+++ b/tasks/queue-dependency-build/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: new-releases

--- a/tasks/recreate-bosh-lite/task.yml
+++ b/tasks/recreate-bosh-lite/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: deployments-buildpacks

--- a/tasks/recreate-shared-cf-deployment/task.yml
+++ b/tasks/recreate-shared-cf-deployment/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: cf-deployment

--- a/tasks/rename-rootfs-for-docker/task.yml
+++ b/tasks/rename-rootfs-for-docker/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: stack-s3
 outputs:

--- a/tasks/run-brats/task.yml
+++ b/tasks/run-brats/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: brats

--- a/tasks/run-buildpack-checksums-specs/task.yml
+++ b/tasks/run-buildpack-checksums-specs/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpack-checksums
 run:

--- a/tasks/run-buildpack-packager-specs/task.yml
+++ b/tasks/run-buildpack-packager-specs/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: buildpack-packager

--- a/tasks/run-buildpack-shared-specs/task.yml
+++ b/tasks/run-buildpack-shared-specs/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/run-buildpack-specs/task.yml
+++ b/tasks/run-buildpack-specs/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/run-buildpacks-ci-specs/task.yml
+++ b/tasks/run-buildpacks-ci-specs/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
 params:

--- a/tasks/run-cflinuxfs2-nc-specs/task.yml
+++ b/tasks/run-cflinuxfs2-nc-specs/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: cflinuxfs2-release

--- a/tasks/run-compile-extensions-specs/task.yml
+++ b/tasks/run-compile-extensions-specs/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: compile-extensions

--- a/tasks/run-concourse2tracker-specs/task.yml
+++ b/tasks/run-concourse2tracker-specs/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: concourse2tracker-source
 run:

--- a/tasks/run-libbuildpack-specs/task.yml
+++ b/tasks/run-libbuildpack-specs/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: libbuildpack

--- a/tasks/run-machete-specs/task.yml
+++ b/tasks/run-machete-specs/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: machete

--- a/tasks/run-rootfs-smoke-test/task.yml
+++ b/tasks/run-rootfs-smoke-test/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: rootfs-smoke-test-manifest-artifacts
   - name: buildpacks-ci

--- a/tasks/run-shared-brats/task.yml
+++ b/tasks/run-shared-brats/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: brats

--- a/tasks/run-shellcheck/task.yml
+++ b/tasks/run-shellcheck/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 
 inputs:
   - name: ci-develop

--- a/tasks/sample-app-smoke-test/task.yml
+++ b/tasks/sample-app-smoke-test/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 
 inputs:
   - name: sample-app

--- a/tasks/test-rootfs/task.yml
+++ b/tasks/test-rootfs/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: cflinuxfs2

--- a/tasks/unclaim-bosh-lite-resource/task.yml
+++ b/tasks/unclaim-bosh-lite-resource/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: resource-pools

--- a/tasks/update-compile-extensions/task.yml
+++ b/tasks/update-compile-extensions/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/update-dependency-in-buildpack/task.yml
+++ b/tasks/update-dependency-in-buildpack/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: buildpack-input

--- a/tasks/update-gem-in-gemfile/task.yml
+++ b/tasks/update-gem-in-gemfile/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: gem
   - name: buildpacks-ci

--- a/tasks/update-libbuildpack/task.yml
+++ b/tasks/update-libbuildpack/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/update-rootfs-filename/task.yml
+++ b/tasks/update-rootfs-filename/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: stack-s3

--- a/tasks/update-rootfs-receipt/task.yml
+++ b/tasks/update-rootfs-receipt/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: receipt-s3

--- a/tasks/upload-bosh-blobs-to-cf-release/task.yml
+++ b/tasks/upload-bosh-blobs-to-cf-release/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: cf-release

--- a/tasks/upload-cflinuxfs2-to-cf-release/task.yml
+++ b/tasks/upload-cflinuxfs2-to-cf-release/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: cf-release-develop

--- a/tasks/verify-buildpack-binaries/task.yml
+++ b/tasks/verify-buildpack-binaries/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: verification-whitelist

--- a/tasks/who-has-the-locks/task.yml
+++ b/tasks/who-has-the-locks/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: public-buildpacks-ci-robots

--- a/tasks/write-bosh-lite-resource-metadata/task.yml
+++ b/tasks/write-bosh-lite-resource-metadata/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
 outputs:

--- a/tasks/write-buildpack-pivnet-metadata/task.yml
+++ b/tasks/write-buildpack-pivnet-metadata/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 
 inputs:
   - name: buildpack

--- a/tasks/write-cats-config/task.yml
+++ b/tasks/write-cats-config/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
 outputs:

--- a/tasks/write-cflinuxfs2-release-pivnet-metadata/task.yml
+++ b/tasks/write-cflinuxfs2-release-pivnet-metadata/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfbuildpacks/ci
+    repository: splatform/cf-ci-buildpacks
 inputs:
   - name: buildpacks-ci
   - name: version


### PR DESCRIPTION
https://trello.com/c/EGkuOC2S/258-2-change-gitconfig-to-cf-suse-bot-in-buildpack-pipelines

*    Make `pipelines/dockerfile.yml` workable, and redirect its output to our org at docker hub.
*    fly cli changed (v 3.3.4).
*    Destination change.
*    Refer all buildpack tasks to the new base image with the suse bot mail inside.
